### PR TITLE
fix mongodb ipv6 localhost problem

### DIFF
--- a/utils/Config.ts
+++ b/utils/Config.ts
@@ -29,5 +29,5 @@ export default acfg({
         START_DISPATCH: true
     },
 
-    DB_URL: "mongodb://localhost:27017/BH3_PS"
+    DB_URL: "mongodb://127.0.0.1:27017/BH3_PS"
 }, { logMissing: true })


### PR DESCRIPTION
the default installation of mongodb does not listen to ipv6 localhost `::1`, but node will resolve `localhost` to `::1`, which will lead to db connection problem
[https://stackoverflow.com/questions/73133094/why-can-i-connect-to-mongo-in-node-using-127-0-0-1-but-not-localhost](https://stackoverflow.com/questions/73133094/why-can-i-connect-to-mongo-in-node-using-127-0-0-1-but-not-localhost)
[https://stackoverflow.com/questions/69957163/mongooseserverselectionerror-connect-econnrefused-127017-in-node-v17-and-mon](https://stackoverflow.com/questions/69957163/mongooseserverselectionerror-connect-econnrefused-127017-in-node-v17-and-mon)
![image](https://github.com/rafi1212122/BH3_PS/assets/112098515/32588471-954b-4a83-b385-a4370a6d67d4)
(on my ipv6 enabled windows)
mongodb default configuration is given below:
```
# network interfaces
net:
  port: 27017
  bindIp: 127.0.0.1
```
![image](https://github.com/rafi1212122/BH3_PS/assets/112098515/667a8f49-11d4-4a1b-8a01-7618a7356b1a)
